### PR TITLE
feat: create concert

### DIFF
--- a/src/api/concertData.js
+++ b/src/api/concertData.js
@@ -1,0 +1,20 @@
+// API CALLS FOR CONCERTS
+const endpoint = 'http://127.0.0.1:8000/concerts';
+
+// CREATE CONCERT
+const createConcert = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// eslint-disable-next-line import/prefer-default-export
+export { createConcert };

--- a/src/components/forms/NewConcertForm.js
+++ b/src/components/forms/NewConcertForm.js
@@ -11,6 +11,7 @@ import CalendarInput from '../inputs/CalendarInput';
 import ArtistSearch from '../inputs/ArtistSearch';
 import VenueSearch from '../inputs/VenueSearch';
 import TimeInput from '../inputs/TimeInput';
+import { createConcert } from '../../api/concertData';
 
 const artistSchema = z.object({
   id: z.string(),
@@ -27,7 +28,7 @@ const venueSchema = z.object({
 const formSchema = z.object({
   artist: artistSchema,
   venue: venueSchema,
-  date: z.date(),
+  date: z.string(),
   time: z.string(),
   tourName: z.string(),
 });
@@ -39,6 +40,7 @@ export default function NewConcertForm() {
 
   function onSubmit(values) {
     console.log(values);
+    createConcert(values);
   }
 
   return (

--- a/src/components/inputs/CalendarInput.js
+++ b/src/components/inputs/CalendarInput.js
@@ -20,13 +20,13 @@ export default function CalendarInput({ control, name, label = 'Date', placehold
             <PopoverTrigger>
               <FormControl>
                 <Button variant="outline" className={cn(`w-full pl-3 text-left font-normal w-${width}`, !field.value && 'text-muted-foreground')}>
-                  {field.value ? format(field.value, 'PPP') : <span>{placeholder}</span>}
+                  {field.value ? format(field.value, 'yyyy-MM-dd') : <span>{placeholder}</span>}
                   <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
                 </Button>
               </FormControl>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="center">
-              <Calendar mode="single" selected={field.value} defaultMonth={field.value} onSelect={field.onChange} captionLayout="dropdown" fromYear={new Date().getFullYear() - 80} toYear={new Date().getFullYear() + 5} />
+              <Calendar mode="single" selected={field.value} defaultMonth={field.value} onSelect={(date) => field.onChange(date ? format(date, 'yyyy-MM-dd') : null)} captionLayout="dropdown" fromYear={new Date().getFullYear() - 80} toYear={new Date().getFullYear() + 5} />
             </PopoverContent>
           </Popover>
           <FormMessage />


### PR DESCRIPTION
# Pull Request: Implement Concert Creation Frontend

## Summary
This PR implements the frontend functionality for creating concerts, including:
- Added concert API service for backend communication
- Updated form schema to handle string-based date format
- Fixed date formatting in CalendarInput component to send proper format to backend
- Integrated concert creation API call in the form submission

## Changes

### 1. Added Concert API Service
**File: `src/api/concertData.js`**
```javascript
// API CALLS FOR CONCERTS
const endpoint = 'http://127.0.0.1:8000/concerts';

// CREATE CONCERT
const createConcert = (payload) => new Promise((resolve, reject) => {
  fetch(endpoint, {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
    },
    body: JSON.stringify(payload),
  })
    .then((response) => response.json())
    .then((data) => resolve(data))
    .catch(reject);
});

// eslint-disable-next-line import/prefer-default-export
export { createConcert };
```

### 2. Updated Concert Form Schema and Submission
**File: `src/components/forms/NewConcertForm.js`**
```javascript
// Added import for concert API
import { createConcert } from '../../api/concertData';

// Updated form schema - date is now string instead of Date object
const formSchema = z.object({
  artist: artistSchema,
  venue: venueSchema,
  date: z.string(), // Changed from z.date() to z.string()
  time: z.string(),
  tourName: z.string(),
});

// Updated form submission to call API
function onSubmit(values) {
  console.log(values);
  createConcert(values); // Added API call to create concert
}
```

### 3. Fixed Date Formatting in CalendarInput
**File: `src/components/inputs/CalendarInput.js`**
```javascript
// Updated display format to show YYYY-MM-DD instead of full date
{field.value ? format(field.value, 'yyyy-MM-dd') : <span>{placeholder}</span>}

// Updated onSelect to format date as string before storing
<Calendar 
  mode="single" 
  selected={field.value} 
  defaultMonth={field.value} 
  onSelect={(date) => field.onChange(date ? format(date, 'yyyy-MM-dd') : null)} 
  captionLayout="dropdown" 
  fromYear={new Date().getFullYear() - 80} 
  toYear={new Date().getFullYear() + 5} 
/>
```

## Technical Details

### Date Handling Changes
- **Before**: Calendar component stored full Date objects, causing backend format issues
- **After**: Calendar component formats dates as `YYYY-MM-DD` strings, matching Django's expected format
- **Display**: Shows dates in consistent `YYYY-MM-DD` format instead of verbose format

### Form Schema Update
- Changed date field validation from `z.date()` to `z.string()` to match the new string-based date handling

### API Integration
- Added `createConcert` function that sends POST requests to Django backend
- Properly handles JSON serialization and response parsing
- Uses Promise-based approach for consistent async handling

## API Usage
The form now sends data in the format expected by the Django backend:
```json
{
  "artist": { "id": "spotify_id", "name": "Artist Name" },
  "venue": { "setlist_fm_id": "venue_id", "name": "Venue Name", "city": "City", "state": "State" },
  "date": "2025-08-21",
  "time": "19:00:00",
  "tourName": "Tour Name"
}
```

## Notes
- Date formatting now consistent between frontend display and backend API
- Form validation updated to match new string-based date format
- Console logging maintained for debugging during development